### PR TITLE
Update FTDI description for ECP5 (non-5g) Versa board

### DIFF
--- a/misc/openocd/ecp5-versa.cfg
+++ b/misc/openocd/ecp5-versa.cfg
@@ -1,7 +1,7 @@
 # this supports ECP5 Versa board
 
 interface ftdi
-ftdi_device_desc "Lattice ECP5 Versa Board"
+ftdi_device_desc "Lattice ECP5_5G VERSA Board"
 ftdi_vid_pid 0x0403 0x6010
 # channel 1 does not have any functionality
 ftdi_channel 0


### PR DESCRIPTION
On my (brand new) ECP5 Versa (the non-5g variant), neither of the openocd cfg files worked,
because the this one had the wrong ftdi_device_desc (even though it's not the 5g one,
the ftdi desc claims it is), while the 5g one had the wrong jtag ID. I realize this is in
direct conflict with #38, so perhaps this needs to allow options (if OpenOCD supports
that - I'm not familiar with the syntax) or we need multiple variants of this file. In either
case, I managed to flash one of the examples (after changing the device model to the non-5g version)
successfully with this change.