### PR TITLE
Add --version commandline option for ecppack

### DIFF
--- a/libtrellis/tools/ecppack.cpp
+++ b/libtrellis/tools/ecppack.cpp
@@ -55,18 +55,26 @@ int main(int argc, char *argv[])
     pos.add("input", 1);
     options.add_options()("bit", po::value<std::string>(), "output bitstream file");
     pos.add("bit", 1);
+    options.add_options()("version", "show current version and exit");
 
     po::variables_map vm;
+
     try {
         po::parsed_options parsed = po::command_line_parser(argc, argv).options(options).positional(pos).run();
         po::store(parsed, vm);
+
+        if (vm.count("version")) {
+            cerr << "Project Trellis ecppack Version " << git_describe_str << endl;
+            return 0;
+        }
+
         po::notify(vm);
     }
-    catch (po::required_option &e) {
+    catch (po::required_option& e) {
         cerr << "Error: input file is mandatory." << endl << endl;
         goto help;
     }
-    catch (std::exception &e) {
+    catch (std::exception& e) {
         cerr << "Error: " << e.what() << endl << endl;
         goto help;
     }


### PR DESCRIPTION
I'm in the process of creating a [Verilog Build System](https://github.com/gojimmypi/msbuildCustomTask/blob/development/VerilogBuild/VerilogBuild.csproj) for Visual Studio as part of my [Verilog Language Extension](https://marketplace.visualstudio.com/items?itemName=gojimmypi.gojimmypi-verilog-language-extension) as inspired by @BarryNolte in his [Project Template for Verilog #25](https://github.com/gojimmypi/VerilogLanguageExtension/pull/25)

I'd like to have this `--version` capability for all external commands used so that better diagnostics can be implemented in the [project file](https://github.com/gojimmypi/msbuildCustomTask/blob/428abadc950b74d2b4801e017009c56282a368ee/VerilogBuild/VerilogBuild.csproj#L527)  similar to that available for `yosys` and `nextpnr`.