### PR TITLE
MachXO2 Support: Part 3

### DIFF
--- a/fuzzers/machxo2/102-oscg/fuzzer.py
+++ b/fuzzers/machxo2/102-oscg/fuzzer.py
@@ -71,9 +71,11 @@ def main(args):
         cfg_r.setup()
         interconnect.fuzz_interconnect_with_netnames(
             cfg_r,
-            ["R1C4_JOSC_OSC"],
+            ["R1C4_JOSC_OSC",
+            "R1C4_JSTDBY_OSC"],
             bidir=True,
-            netdir_override={"R1C4_JOSC_OSC" : "driver"})
+            netdir_override={"R1C4_JOSC_OSC" : "driver",
+                             "R1C4_JSTDBY_OSC" : "sink"})
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="OSCH Fuzzer.")

--- a/libtrellis/src/PyTrellis.cpp
+++ b/libtrellis/src/PyTrellis.cpp
@@ -304,6 +304,7 @@ PYBIND11_MODULE (pytrellis, m)
             .def("set_value", &EnumSettingBits::set_value);
 
     class_<FixedConnection>(m, "FixedConnection")
+            .def(init<>())
             .def_readwrite("source", &FixedConnection::source)
             .def_readwrite("sink", &FixedConnection::sink);
 

--- a/libtrellis/src/RoutingGraph.cpp
+++ b/libtrellis/src/RoutingGraph.cpp
@@ -179,10 +179,25 @@ RoutingId RoutingGraph::globalise_net_machxo2(int row, int col, const std::strin
                       // wonderful 1-based column numbering, and lack of dedicated
                       // PIO tiles on the left and right.
                       // Top and bottom unaffected due to dedicated PIO tiles.
-                      bool pio_wire = (db_name.find("PADD") != string::npos ||
+                      // TODO: Convert to regex.
+                      bool pio_wire = (
+                          db_name.find("DI") != string::npos ||
+                          db_name.find("JDI") != string::npos ||
+                          db_name.find("PADD") != string::npos ||
+                          db_name.find("INDD") != string::npos ||
                           db_name.find("IOLDO") != string::npos ||
                           db_name.find("IOLTO") != string::npos ||
-                          db_name.find("JINCK") != string::npos);
+                          db_name.find("JCE") != string::npos ||
+                          db_name.find("JCLK") != string::npos ||
+                          db_name.find("JLSR") != string::npos ||
+                          db_name.find("JONEG") != string::npos ||
+                          db_name.find("JOPOS") != string::npos ||
+                          db_name.find("JTS") != string::npos ||
+                          db_name.find("JIN") != string::npos ||
+                          db_name.find("JIP") != string::npos ||
+                          // Connections to global mux
+                          db_name.find("JINCK") != string::npos
+                      );
 
                       if((id.loc.x == -1) && pio_wire)
                           id.loc.x = 0;
@@ -192,10 +207,24 @@ RoutingId RoutingGraph::globalise_net_machxo2(int row, int col, const std::strin
                   id.loc.x += std::stoi(g.substr(1));
 
                   if(id.loc.x > max_col) {
-                      bool pio_wire = (db_name.find("PADD") != string::npos ||
-                        db_name.find("IOLDO") != string::npos ||
-                        db_name.find("IOLTO") != string::npos||
-                        db_name.find("JINCK") != string::npos);
+                      bool pio_wire = (
+                          db_name.find("DI") != string::npos ||
+                          db_name.find("JDI") != string::npos ||
+                          db_name.find("PADD") != string::npos ||
+                          db_name.find("INDD") != string::npos ||
+                          db_name.find("IOLDO") != string::npos ||
+                          db_name.find("IOLTO") != string::npos ||
+                          db_name.find("JCE") != string::npos ||
+                          db_name.find("JCLK") != string::npos ||
+                          db_name.find("JLSR") != string::npos ||
+                          db_name.find("JONEG") != string::npos ||
+                          db_name.find("JOPOS") != string::npos ||
+                          db_name.find("JTS") != string::npos ||
+                          db_name.find("JIN") != string::npos ||
+                          db_name.find("JIP") != string::npos ||
+                          // Connections to global mux
+                          db_name.find("JINCK") != string::npos
+                      );
 
                       // Same deal as left side, except the position exceeds
                       // the maximum row.


### PR DESCRIPTION
This PR fixes some routing graph oversights, making sure that the left-right tiles in MachXO2 and the STDBY pin of the internal oscillator are properly connected to the routing graph. A more general solution may be required for all MachXO2 parts, but this will be fine for `LCMXO2-1200HC` for now.