### PR TITLE
Fix windows cross-compile

### DIFF
--- a/libtrellis/tools/ecpbram.cpp
+++ b/libtrellis/tools/ecpbram.cpp
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #ifdef _WIN32
 #define NOMINMAX
-#include "Windows.h"
+#include "windows.h"
 #undef NOMINMAX
 #else
 #include <unistd.h>


### PR DESCRIPTION
On cross compile environment filename is in always in lower case.