### PR TITLE
ecppll: fix broken port names in highres mode, fix regression

### DIFF
--- a/libtrellis/tools/ecppll.cpp
+++ b/libtrellis/tools/ecppll.cpp
@@ -398,7 +398,10 @@ void write_pll_config(const pll_params & params, const string &name, ofstream& f
     file << "assign phasesel_hw = phasesel - 1;\n";
   }
   file << "(* FREQUENCY_PIN_CLKI=\"" << params.clkin_frequency << "\" *)\n";
-  file << "(* FREQUENCY_PIN_CLKOP=\"" << params.fout << "\" *)\n";
+
+  if(params.mode != pll_mode::HIGHRES)
+    file << "(* FREQUENCY_PIN_CLKOP=\"" << params.fout << "\" *)\n";
+
   if(params.secondary[0].enabled)
     file << "(* FREQUENCY_PIN_CLKOS=\"" << params.secondary[0].freq << "\" *)\n";
   if(params.secondary[1].enabled)
@@ -453,7 +456,12 @@ void write_pll_config(const pll_params & params, const string &name, ofstream& f
   else
     file << "        .STDBY(1'b0),\n";
   file << "        .CLKI(" << params.clkin_name << "),\n";
-  file << "        .CLKOP(" << params.clkout0_name << "),\n";
+
+  if(params.mode == pll_mode::HIGHRES)
+    file << "        .CLKOP(clkfb),\n";
+  else
+    file << "        .CLKOP(" << params.clkout0_name << "),\n";
+
   if(params.secondary[0].enabled){
     if(params.mode == pll_mode::HIGHRES)
       file << "        .CLKOS(" << params.clkout0_name << "),\n";
@@ -466,16 +474,17 @@ void write_pll_config(const pll_params & params, const string &name, ofstream& f
   if(params.secondary[2].enabled){
     file << "        .CLKOS3(" << params.secondary[2].name << "),\n";
   }
-  if(params.internal_feedback)
-  {
+
+  if(params.internal_feedback || params.mode == pll_mode::HIGHRES)
     file << "        .CLKFB(clkfb),\n";
-    file << "        .CLKINTFB(clkfb),\n";
-  }
   else
-  {
     file << "        .CLKFB(" <<  params.feedback_wname[params.feedback_clkout] << "),\n";
+
+  if(params.internal_feedback)
+    file << "        .CLKINTFB(clkfb),\n";
+  else
     file << "        .CLKINTFB(),\n";
-  }
+
   if(params.dynamic)
   {
     file << "        .PHASESEL0(phasesel_hw[0]),\n";


### PR DESCRIPTION
This is the regression introduced by commit b2884bf: CLKOP and CLKFB parameters should not be named as clkout0_name.

P.S. Tested when generating the reference frequency for the UART (256 * 115200 Hz) from system clock (25 MHz). The board used is Colorlight i5 v7.0 with Muse Lab development board.