### PR TITLE
allow user specified LM_LICENSE_FILE

### DIFF
--- a/diamond.sh
+++ b/diamond.sh
@@ -58,7 +58,7 @@ if $WINDOWS; then
 else
 	export LD_LIBRARY_PATH="${bindir}:${fpgabindir}"
 fi
-export LM_LICENSE_FILE="${diamonddir}/license/license.dat"
+export LM_LICENSE_FILE="${LM_LICENSE_FILE:=${diamonddir}/license/license.dat}"
 
 set -ex
 if [[ $2 == *.ncl ]]

--- a/diamond_tcl.sh
+++ b/diamond_tcl.sh
@@ -41,7 +41,7 @@ if $WINDOWS; then
 else
 	export LD_LIBRARY_PATH="${bindir}:${fpgabindir}"
 fi
-export LM_LICENSE_FILE="${diamonddir}/license/license.dat"
+export LM_LICENSE_FILE="${LM_LICENSE_FILE:=${diamonddir}/license/license.dat}"
 
 if $WINDOWS; then
     $FOUNDRY/userware/NT/bin/nt64/ispTcl $1


### PR DESCRIPTION
If the user manually specifies `LM_LICENSE_FILE` (maybe because the license file is in a non-standard location), use the specified location instead of the hardcoded location.