### PR TITLE
Add missing comma causing implicit str concat

### DIFF
--- a/timing/util/pip_classes.py
+++ b/timing/util/pip_classes.py
@@ -147,7 +147,7 @@ zero_delay_classes = {
     "q_to_span2vn_n1",
     "q_to_span6he_e3",
     "q_to_span6hw_w3",
-    "span0hl_to_c"
+    "span0hl_to_c",
     "span0hl_to_ce",
     "span0hl_to_d",
     "span0hl_to_m",


### PR DESCRIPTION
This was found using a regex and is most likely a bug. The two adjacent strings get implicitly concatenated, which is not the right logic.