### PR TITLE
Readme: Install to /usr/local instead of /usr (?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Install _libtrellis_ and associated tools. You _must_ run `cmake` from the libtr
 Out-of-tree builds are currently unsupported when coupled with `nextpnr`:
 
     cd libtrellis
-    cmake -DCMAKE_INSTALL_PREFIX=/usr .
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local .
     make
     sudo make install
 
 Clone and install **latest git master** versions (Yosys 0.8 is not sufficient for ECP5 development) of [Yosys](https://github.com/YosysHQ/yosys)
  and [nextpnr](https://github.com/YosysHQ/nextpnr) according to their own instructions. Ensure
  to include the [ECP5 architecture](https://github.com/YosysHQ/nextpnr#nextpnr-ecp5) when building nextpnr; and point it towards your prjtrellis
- folder.  (for example: `cmake -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX=/usr .`)
+ folder.  (for example: `cmake -DARCH=ecp5 -DTRELLIS_INSTALL_PREFIX=/usr/local .`)
 
 You should now be able to build the [examples](examples).
 


### PR DESCRIPTION
According to my (quick) research /usr/local is for stuff manually compiled, so we rather should install there. This (/usr/local) is also the path mentionned in the compiling-instructions for nextpnr. I might be wrong however and the Readme of nextpnr needs to be updated, feel free to reject this PR in this case. Anyway something is not consistent at the moment and it creates problems like here: https://github.com/YosysHQ/nextpnr/issues/781 