### PR TITLE
libtrellis: LUT permutation support for ECP5

### DIFF
--- a/libtrellis/include/Chip.hpp
+++ b/libtrellis/include/Chip.hpp
@@ -177,7 +177,7 @@ public:
     int get_max_col() const;
 
     // Build the routing graph for the chip
-    shared_ptr<RoutingGraph> get_routing_graph();
+    shared_ptr<RoutingGraph> get_routing_graph(bool include_lutperm_pips = false);
 
     vector<vector<vector<pair<string, string>>>> tiles_at_location;
 
@@ -191,7 +191,7 @@ public:
 
 private:
     // Factory functions
-    shared_ptr<RoutingGraph> get_routing_graph_ecp5();
+    shared_ptr<RoutingGraph> get_routing_graph_ecp5(bool include_lutperm_pips = false);
     shared_ptr<RoutingGraph> get_routing_graph_machxo2();
 };
 

--- a/libtrellis/include/DedupChipdb.hpp
+++ b/libtrellis/include/DedupChipdb.hpp
@@ -81,12 +81,13 @@ struct DdArcData
     ArcClass cls;
     int32_t delay;
     ident_t tiletype;
+    int16_t lutperm_flags;
 };
 
 inline bool operator==(const DdArcData &a, const DdArcData &b)
 {
     return a.srcWire == b.srcWire && a.sinkWire == b.sinkWire && a.cls == b.cls && a.delay == b.delay &&
-           a.tiletype == b.tiletype;
+           a.tiletype == b.tiletype && a.lutperm_flags == b.lutperm_flags;
 }
 
 struct WireData
@@ -241,6 +242,7 @@ struct hash<Trellis::DDChipDb::DdArcData>
         boost::hash_combine(seed, hash<int8_t>()(arc.cls));
         boost::hash_combine(seed, hash<int32_t>()(arc.delay));
         boost::hash_combine(seed, hash<Trellis::ident_t>()(arc.tiletype));
+        boost::hash_combine(seed, hash<uint16_t>()(arc.lutperm_flags));
         return seed;
     }
 };
@@ -355,7 +357,7 @@ struct DedupChipdb : public IdStore
     LocationData get_cs_data(checksum_t id);
 };
 
-shared_ptr<DedupChipdb> make_dedup_chipdb(Chip &chip);
+shared_ptr<DedupChipdb> make_dedup_chipdb(Chip &chip, bool include_lutperm_pips = false);
 
 /*
 An optimized chip database is a database with the following properties, intended to be used in place-and-route flows.

--- a/libtrellis/include/RoutingGraph.hpp
+++ b/libtrellis/include/RoutingGraph.hpp
@@ -64,6 +64,7 @@ struct RoutingArc
     RoutingId source;
     RoutingId sink;
     bool configurable = false;
+    uint16_t lutperm_flags = 0;
     mutable int cdb_id = 0;
 };
 

--- a/libtrellis/src/DedupChipdb.cpp
+++ b/libtrellis/src/DedupChipdb.cpp
@@ -32,9 +32,9 @@ DedupChipdb::DedupChipdb()
 DedupChipdb::DedupChipdb(const IdStore &base) : IdStore(base)
 {}
 
-shared_ptr<DedupChipdb> make_dedup_chipdb(Chip &chip)
+shared_ptr<DedupChipdb> make_dedup_chipdb(Chip &chip, bool include_lutperm_pips)
 {
-    shared_ptr<RoutingGraph> graph = chip.get_routing_graph();
+    shared_ptr<RoutingGraph> graph = chip.get_routing_graph(include_lutperm_pips);
     for (auto &loc : graph->tiles) {
         const auto &td = loc.second;
         // Index bels, wires and arcs
@@ -87,6 +87,7 @@ shared_ptr<DedupChipdb> make_dedup_chipdb(Chip &chip)
             ad.delay = 1;
             ad.sinkWire = RelId{Location(ra.sink.loc.x - x, ra.sink.loc.y - y), graph->tiles.at(ra.sink.loc).wires.at(ra.sink.id).cdb_id};
             ad.srcWire = RelId{Location(ra.source.loc.x - x, ra.source.loc.y - y), graph->tiles.at(ra.source.loc).wires.at(ra.source.id).cdb_id};
+            ad.lutperm_flags = ra.lutperm_flags;
             ld.arcs.push_back(ad);
         }
 

--- a/libtrellis/src/PyTrellis.cpp
+++ b/libtrellis/src/PyTrellis.cpp
@@ -503,7 +503,8 @@ PYBIND11_MODULE (pytrellis, m)
             .def_readwrite("sinkWire", &DdArcData::sinkWire)
             .def_readwrite("cls", &DdArcData::cls)
             .def_readwrite("delay", &DdArcData::delay)
-            .def_readwrite("tiletype", &DdArcData::tiletype);
+            .def_readwrite("tiletype", &DdArcData::tiletype)
+            .def_readwrite("lutperm_flags", &DdArcData::lutperm_flags);
 
     class_<WireData>(m, "WireData")
             .def_readwrite("name", &WireData::name)
@@ -546,7 +547,8 @@ PYBIND11_MODULE (pytrellis, m)
             .def("ident", &DedupChipdb::ident)
             .def("to_str", &DedupChipdb::to_str);
 
-    m.def("make_dedup_chipdb", make_dedup_chipdb);
+    m.def("make_dedup_chipdb", make_dedup_chipdb,
+        py::arg("chip"), py::arg("include_lutperm_pips")=false);
 
     class_<OptimizedChipdb, shared_ptr<OptimizedChipdb>>(m, "OptimizedChipdb")
             .def_readwrite("tiles", &OptimizedChipdb::tiles)


### PR DESCRIPTION
This adds the pseudo-pips to the database necessary for LUT permutation