### PR TITLE
examples/Makefiles: fix PHONY targets

### DIFF
--- a/examples/ecp5_evn/Makefile
+++ b/examples/ecp5_evn/Makefile
@@ -20,4 +20,4 @@ prog: ${PROJ}.svf
 clean:
 	rm -f *.svf *.bit *.config *.json
 
-.PHONY: prog clean
+.PHONY: all prog clean

--- a/examples/ecp5_evn_multiboot/Makefile
+++ b/examples/ecp5_evn_multiboot/Makefile
@@ -19,5 +19,5 @@ multiboot.mcs: multiboot.bin
 clean:
 	rm -f *.svf *.bit *.config *.json multiboot.bin multiboot.mcs
 
-.PHONY: prog clean
+.PHONY: all clean
 .PRECIOUS: blinky1.json blinky1_out.config blinky1.bit blinky2.json blinky2_out.config blinky2.bit multiboot.bin multiboot.mcs

--- a/examples/tinyfpga_ax/Makefile
+++ b/examples/tinyfpga_ax/Makefile
@@ -46,3 +46,5 @@ ${PROJ}-nextpnr.txt: ${PROJ}.json
 clean:
 	rm -rf ${PROJ}.tmp ${PROJ}_out.ncl ${PROJ}*.bit ${PROJ}.jed ${PROJ}.dump \
 		${PROJ}.twr ${PROJ}*.txt ${PROJ}.json ${PROJ}-nextpnr.* ${PROJ}*.hex
+
+.PHONY: all stats clean

--- a/examples/tinyfpga_rev1/Makefile
+++ b/examples/tinyfpga_rev1/Makefile
@@ -17,5 +17,5 @@ clean:
 prog: ${PROJ}.bit
 	tinyprog -p $<
 
-.PHONY: clean
+.PHONY: all clean prog
 

--- a/examples/tinyfpga_rev2/Makefile
+++ b/examples/tinyfpga_rev2/Makefile
@@ -17,5 +17,5 @@ prog: ${PROJ}.bit
 clean:
 	rm -f *.bit *.svf *_out.config *.json
 
-.PHONY: clean
+.PHONY: all prog clean
 .PRECIOUS: ${PROJ}.json ${PROJ}_out.config

--- a/examples/ulx3s/Makefile
+++ b/examples/ulx3s/Makefile
@@ -39,3 +39,5 @@ pll_%.v:
 clean:
 	$(RM) *.config *.bit .*.d *.svf
 -include .*.d
+
+.PHONY: all clean

--- a/examples/ulx3s_12k_multiboot/Makefile
+++ b/examples/ulx3s_12k_multiboot/Makefile
@@ -19,5 +19,5 @@ multiboot.mcs: multiboot.bin
 clean:
 	rm -f *.svf *.bit *.config *.json multiboot.bin multiboot.mcs
 
-.PHONY: prog clean
+.PHONY: all clean
 .PRECIOUS: blinky1.json blinky1_out.config blinky1.bit blinky2.json blinky2_out.config blinky2.bit multiboot.bin multiboot.mcs

--- a/examples/versa5g/Makefile
+++ b/examples/versa5g/Makefile
@@ -24,5 +24,5 @@ prog: ${PROJ}.svf
 clean:
 	rm -f *.bit *.svf *_out.config *.json pattern.vh
 
-.PHONY: prog clean
+.PHONY: all prog clean
 .PRECIOUS: ${PROJ}.json ${PROJ}_out.config


### PR DESCRIPTION
In some Makefiles, the PHONY target was missing or not consistent
with the actual targets in the Makefile.

Thanks!