### PR TITLE
Fix arch package building workflow

### DIFF
--- a/.github/workflows/arch-pkg.yml
+++ b/.github/workflows/arch-pkg.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Arch Linux package
-        uses: FFY00/build-arch-package@master
+        uses: FFY00/build-arch-package@v1
         with:
           PKGBUILD: $GITHUB_WORKSPACE/.github/archlinux/PKGBUILD
 


### PR DESCRIPTION
Switch to use v1 tag instead of relying on master branch (which has been dropped in favor of main).