### PR TITLE
diamond.sh: Add extra logic to set diamonddir automatically for 3.12 …

### DIFF
--- a/diamond.sh
+++ b/diamond.sh
@@ -31,7 +31,14 @@ else
 fi
 
 if $WINDOWS; then
-	diamonddir="${DIAMONDDIR:-/c/lscc/diamond/${diamondver}_x64}"
+	case $diamondver in
+		"3.12")
+			diamonddir="${DIAMONDDIR:-/c/lscc/diamond/${diamondver}}"
+			;;
+		*)
+			diamonddir="${DIAMONDDIR:-/c/lscc/diamond/${diamondver}_x64}"
+			;;
+	esac
 else
 	diamonddir="${DIAMONDDIR:-/usr/local/diamond/${diamondver}_x64}"
 fi


### PR DESCRIPTION
…on Windows- the default path changed.

Self-explanatory. I don't know if this applies to Linux yet, but it seems that 32-bit support was dropped for Windows 10 as of 3.12, so they got rid of the suffix for the default path.