### PR TITLE
CMake: prune no longer necessary Boost definitions

### DIFF
--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -39,10 +39,7 @@ if (WASI)
     add_definitions(
         -DBOOST_EXCEPTION_DISABLE
         -DBOOST_NO_EXCEPTIONS
-        -DBOOST_SP_NO_ATOMIC_ACCESS
-        -DBOOST_AC_DISABLE_THREADS
         -DBOOST_NO_CXX11_HDR_MUTEX
-        -DBOOST_NO_CXX11_HDR_ATOMIC
     )
 else()
     set(USE_THREADS ON)


### PR DESCRIPTION
These are not required as of wasi-sdk-19 and Boost 1.81.