### PR TITLE
ecpunpack: Fix error message on bad usage

### DIFF
--- a/libtrellis/tools/ecpunpack.cpp
+++ b/libtrellis/tools/ecpunpack.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
         po::notify(vm);
     }
     catch (po::required_option &e) {
-        cerr << "Error: input file is mandatory." << endl << endl;
+        cerr << "Error: Option " << e.get_option_name() << " is mandatory." << endl << endl;
         goto help;
     }
     catch (std::exception &e) {


### PR DESCRIPTION
Before:

	$ ecpunpack top.bit
	Error: input file is mandatory.
	[...]

After:

	$ ecpunpack top.bit
	Error: --textcfg is mandatory.
	[...]