### PR TITLE
Make CURRENT_GIT_VERSION logic robust in release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.gitversion export-subst

--- a/.gitversion
+++ b/.gitversion
@@ -1,0 +1,1 @@
+$Format:%cs-%h$

--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -117,20 +117,22 @@ endfunction()
 # Avoid perturbing build if git version hasn't changed
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/generated")
 set(LAST_GIT_VERSION "")
+
+# Get version string in following order of priority:
+#  1) Externally defined -DCURRENT_GIT_VERSION
+#  2) git-archive export-subst trick from .gitversion
+#  3) Call git describe (if available)
 if (NOT DEFINED CURRENT_GIT_VERSION)
-    execute_process(COMMAND git describe --tags --always OUTPUT_VARIABLE CURRENT_GIT_VERSION WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  file(READ "${CMAKE_SOURCE_DIR}/.gitversion" CURRENT_GIT_VERSION)
+  if ("${CURRENT_GIT_VERSION}" STREQUAL "$Format:%cs-%h$") # if not substituted we're in a git checkout
+    if (GIT_EXECUTABLE)
+      execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always OUTPUT_VARIABLE CURRENT_GIT_VERSION WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+      string(STRIP "${CURRENT_GIT_VERSION}" CURRENT_GIT_VERSION)
+    endif()
+  else() # we're in a git-archive tarball
+    file(READ "${CMAKE_SOURCE_DIR}/.gitversion" CURRENT_GIT_VERSION)
+  endif()
 endif()
-string(STRIP "${CURRENT_GIT_VERSION}" CURRENT_GIT_VERSION)
-if (EXISTS "${CMAKE_BINARY_DIR}/generated/last_git_version")
-    file(READ "${CMAKE_BINARY_DIR}/generated/last_git_version" LAST_GIT_VERSION)
-endif()
-if (NOT ("${LAST_GIT_VERSION}" STREQUAL "${CURRENT_GIT_VERSION}") OR NOT GIT_EXECUTABLE)
-    configure_file(
-      ${CMAKE_SOURCE_DIR}/tools/version.cpp.in
-      ${CMAKE_BINARY_DIR}/generated/version.cpp
-    )
-endif()
-file(WRITE "${CMAKE_BINARY_DIR}/generated/last_git_version" CURRENT_GIT_VERSION)
 
 if (BUILD_ECPBRAM)
     add_executable(${PROGRAM_PREFIX}ecpbram ${INCLUDE_FILES} tools/ecpbram.cpp "${CMAKE_BINARY_DIR}/generated/version.cpp")


### PR DESCRIPTION
This automatically embeds git version information into tarballs built with git-archive. This even works for tarballs downloaded from Github.

Essentially the same trick as in https://github.com/YosysHQ/yosys/pull/3138 with one complication: git-tag information is not available to the export-subst (see gitattributes(5)) format string so we use the commit date instead.

We retain the current git-describe based string for git checkouts but it might be advisable to align this to be the HEAD commit date plus commit hash too.