### PR TITLE
JEDEC file support

### DIFF
--- a/libtrellis/tools/ecppack.cpp
+++ b/libtrellis/tools/ecppack.cpp
@@ -42,13 +42,31 @@ uint16_t calc_checksum(std::string bytes)
 }
 
 uint32_t get_num_config_fuses(Trellis::ChipInfo &ci) {
-    if(ci.name == "LCMXO2-4000") {
+    if(ci.name == "LCMXO2-256") {
+        return (575 + 0 + 1)*128; // No UFM, 1 dummy page at end.
+    } else if(ci.name == "LCMXO2-640") {
+        return (1151 + 191 + 1)*128; // UFM is 0 bytes after end of CFG, 1 dummy page at end.
+    } else if(ci.name == "LCMXO2-1200" || ci.name == "LCMXO2-640U") {
+        return (2175 + 511 + 1)*128; // UFM is 0 bytes after end of CFG, 1 dummy page at end.
+    } else if(ci.name == "LCMXO2-2000" || ci.name == "LCMXO2-1200U") {
+        return (3198 + 639 + 1)*128; // UFM is 0 bytes after end of CFG, 1 dummy page at end.
+    } else if(ci.name == "LCMXO2-4000" || ci.name == "LCMXO2-2000U") {
         return (5758 + 767 + 1)*128; // UFM is 0 bytes after end of CFG, 1 dummy page at end.
-    } if(ci.name == "LCMXO2-7000") {
+    } else if(ci.name == "LCMXO2-7000") {
         return (9211 + 1 + 2046 + 2)*128; // UFM is 16 bytes after end of CFG, 2 dummy pages at end.
     } else {
         throw runtime_error(fmt("Can not extract number of config fuses from FPGA family " << ci.name));
     }
+}
+
+int num_digits(uint32_t num) {
+    int count = 0;
+    do {
+        num /= 10;
+        count++;
+    } while(num != 0);
+
+    return count;
 }
 
 int main(int argc, char *argv[])
@@ -68,6 +86,7 @@ int main(int argc, char *argv[])
     options.add_options()("svf", po::value<std::string>(), "output SVF file");
     options.add_options()("svf-rowsize", po::value<int>(), "SVF row size in bits (default 8000)");
     options.add_options()("jed", po::value<std::string>(), "output JED file");
+    options.add_options()("jed-note", po::value<vector<std::string>>(), "emit NOTE field in JED file");
     options.add_options()("compress", "compress bitstream to reduce size");
     options.add_options()("spimode", po::value<std::string>(), "SPI Mode to use (fast-read, dual-spi, qspi)");
     options.add_options()("background", "enable background reconfiguration in bitstream");
@@ -377,8 +396,15 @@ help:
 
         jed_file << "\x02*" << endl; // STX plus "design specification" (not filled in).
         full_checksum += calc_checksum("\x02*\n");
-        // jed_file << "\x03" << hex << uppercase << setw(4) << full_checksum << endl;
-        // return 0;
+
+        if (vm.count("jed-note")) {
+            ostringstream note_field;
+            for(auto &n: vm["jed-note"].as<vector<string>>()) {
+                note_field << "NOTE " << n << "*" << endl;
+                full_checksum += calc_checksum(note_field.str());
+                jed_file << note_field.str();
+            }
+        }
 
         ostringstream fusecnt_field;
         uint32_t fusecnt;
@@ -389,6 +415,7 @@ help:
             return 1;
         }
         
+        // TODO: QP (package information not implied in textual representation).
         fusecnt_field << "QF" << fusecnt << '*' << endl;
         full_checksum += calc_checksum(fusecnt_field.str());
         jed_file << fusecnt_field.str();
@@ -397,9 +424,26 @@ help:
         full_checksum += calc_checksum("G0*\n");
         jed_file << "F0*" << endl; // Default fuse value.
         full_checksum += calc_checksum("F0*\n");
-        jed_file << "L0" << endl;
-        full_checksum += calc_checksum("L0\n");
 
+        // The JEDEC spec says leading 0s are optional. My own experience is
+        // that some programmers require leading 0s.
+        ostringstream list_field;
+        list_field << "L" << setw(num_digits(fusecnt)) << setfill('0') << 0 << endl;
+        full_checksum += calc_checksum(list_field.str());
+        jed_file << list_field.str();
+
+        // Strip the leading comment- it wastes precious fuse space and
+        // some programmers (e.g STEP-MXO2) even rely on the preamble being
+        // the first bytes.
+        vector<uint8_t> preamble = {0xFF, 0xFF, 0xBD, 0xB3, 0xFF, 0xFF };
+        auto start_iter = search(begin(bitstream), end(bitstream), begin(preamble), end(preamble));
+
+        if(start_iter == end(bitstream)) {
+            cerr << "Could not extract preamble from bitstream" << endl;
+            return 1;
+        }
+
+        auto start_offs = start_iter - bitstream.begin();
 
         size_t i = 0;
         while(i < fusecnt/8) {
@@ -407,9 +451,9 @@ help:
                 size_t len = min(size_t(16), bitstream.size() - i);
 
                 for (unsigned int j = 0; j < len; j++) {
-                    uint8_t byte = uint8_t(bitstream[j + i]);
+                    uint8_t byte = uint8_t(bitstream[j + i + start_offs]);
                     checksum += reverse_byte(byte);
-                    full_checksum += calc_checksum(std::bitset<8>{byte}.to_string());
+                    full_checksum += calc_checksum(bitset<8>{byte}.to_string());
                     jed_file << std::bitset<8>{byte};
                 }
 
@@ -442,10 +486,10 @@ help:
         jed_file << "*" << endl;
         full_checksum += calc_checksum("*\n");
 
-        ostringstream oss;
-        oss << "C" << hex << uppercase << setfill('0') << setw(4) << checksum << '*' << endl;
-        full_checksum += calc_checksum(oss.str());
-        jed_file << oss.str();
+        ostringstream checksum_field;
+        checksum_field << "C" << hex << uppercase << setfill('0') << setw(4) << checksum << '*' << endl;
+        full_checksum += calc_checksum(checksum_field.str());
+        jed_file << checksum_field.str();
 
         full_checksum += calc_checksum("\x03");
         jed_file << "\x03" << hex << uppercase << setw(4) << setfill('0') << full_checksum << endl;

--- a/libtrellis/tools/ecppack.cpp
+++ b/libtrellis/tools/ecppack.cpp
@@ -29,6 +29,28 @@ uint32_t convert_hexstring(std::string value_str)
     return uint32_t(strtoul(value_str.c_str(), nullptr, 0));
 }
 
+uint16_t calc_checksum(std::string bytes)
+{
+    uint16_t checksum = 0;
+
+    for(auto &c: bytes)
+    {
+        checksum += c;
+    }
+
+    return checksum;
+}
+
+uint32_t get_num_config_fuses(Trellis::ChipInfo &ci) {
+    if(ci.name == "LCMXO2-4000") {
+        return (5758 + 767 + 1)*128; // UFM is 0 bytes after end of CFG, 1 dummy page at end.
+    } if(ci.name == "LCMXO2-7000") {
+        return (9211 + 1 + 2046 + 2)*128; // UFM is 16 bytes after end of CFG, 2 dummy pages at end.
+    } else {
+        throw runtime_error(fmt("Can not extract number of config fuses from FPGA family " << ci.name));
+    }
+}
+
 int main(int argc, char *argv[])
 {
     using namespace Trellis;
@@ -45,6 +67,7 @@ int main(int argc, char *argv[])
     options.add_options()("freq", po::value<std::string>(), "config frequency in MHz");
     options.add_options()("svf", po::value<std::string>(), "output SVF file");
     options.add_options()("svf-rowsize", po::value<int>(), "SVF row size in bits (default 8000)");
+    options.add_options()("jed", po::value<std::string>(), "output JED file");
     options.add_options()("compress", "compress bitstream to reduce size");
     options.add_options()("spimode", po::value<std::string>(), "SPI Mode to use (fast-read, dual-spi, qspi)");
     options.add_options()("background", "enable background reconfiguration in bitstream");
@@ -336,6 +359,96 @@ help:
             svf_file << "\t\t\tTDO  (00000100)" << endl;
             svf_file << "\t\t\tMASK (00002100);" << endl;
         }
+    }
+
+    if (vm.count("jed")) {
+        // Create JTAG bitstream without SPI flash related settings, as these
+        // seem to confuse the chip sometimes when configuring over JTAG
+        if (!bitopts.empty() && !(bitopts.size() == 1 && bitopts.count("compress"))) {
+            bitopts.erase("spimode");
+            bitopts.erase("freq");
+            b = Bitstream::serialise_chip(c, bitopts);
+        }
+
+        vector<uint8_t> bitstream = b.get_bytes();
+        ofstream jed_file(vm["jed"].as<string>(), ios_base::binary);
+        uint16_t checksum = 0;
+        uint16_t full_checksum = 0;
+
+        jed_file << "\x02*" << endl; // STX plus "design specification" (not filled in).
+        full_checksum += calc_checksum("\x02*\n");
+        // jed_file << "\x03" << hex << uppercase << setw(4) << full_checksum << endl;
+        // return 0;
+
+        ostringstream fusecnt_field;
+        uint32_t fusecnt;
+        try {
+            fusecnt = get_num_config_fuses(c.info);
+        } catch (runtime_error &e) {
+            cerr << "Failed to extract JED file size: " << e.what() << endl;
+            return 1;
+        }
+        
+        fusecnt_field << "QF" << fusecnt << '*' << endl;
+        full_checksum += calc_checksum(fusecnt_field.str());
+        jed_file << fusecnt_field.str();
+        
+        jed_file << "G0*" << endl; // Security fuse not supported yet.
+        full_checksum += calc_checksum("G0*\n");
+        jed_file << "F0*" << endl; // Default fuse value.
+        full_checksum += calc_checksum("F0*\n");
+        jed_file << "L0" << endl;
+        full_checksum += calc_checksum("L0\n");
+
+
+        size_t i = 0;
+        while(i < fusecnt/8) {
+            if(i < bitstream.size()) {
+                size_t len = min(size_t(16), bitstream.size() - i);
+
+                for (unsigned int j = 0; j < len; j++) {
+                    uint8_t byte = uint8_t(bitstream[j + i]);
+                    checksum += reverse_byte(byte);
+                    full_checksum += calc_checksum(std::bitset<8>{byte}.to_string());
+                    jed_file << std::bitset<8>{byte};
+                }
+
+                // Pad to 128 bits if at end of bitstream.
+                if(len < 16) {
+                    for(unsigned int k = 0; k < 16 - len; k++) {
+                        uint8_t byte = 0;
+                        checksum += reverse_byte(byte);
+                        full_checksum += calc_checksum(std::bitset<8>{byte}.to_string());
+                        jed_file << std::bitset<8>{byte};
+                    }
+                }
+                
+
+            } else {
+                // Fill in remaining 128-bit rows
+                for(unsigned int j = 0; j < 16; j++) {
+                    uint8_t byte = 0;
+                    checksum += reverse_byte(byte);
+                    full_checksum += calc_checksum(std::bitset<8>{byte}.to_string());
+                    jed_file << std::bitset<8>{byte};
+                }
+            }
+
+            jed_file << endl;
+            full_checksum += calc_checksum("\n");
+            i += 16;
+        }
+
+        jed_file << "*" << endl;
+        full_checksum += calc_checksum("*\n");
+
+        ostringstream oss;
+        oss << "C" << hex << uppercase << setfill('0') << setw(4) << checksum << '*' << endl;
+        full_checksum += calc_checksum(oss.str());
+        jed_file << oss.str();
+
+        full_checksum += calc_checksum("\x03");
+        jed_file << "\x03" << hex << uppercase << setw(4) << setfill('0') << full_checksum << endl;
     }
 
     return 0;


### PR DESCRIPTION
Some MachXO2 boards (e.g. the [STEP-MXO2](https://www.tindie.com/products/evoinmotion/fpga-development-board-step-mxo2/)) have an on-board microcontroller which talks to the FPGA JTAG on the user's behalf. Sometimes, these microcontrollers only accepts Lattice-generated JEDEC files, not `.bit` or SVD files. So this PR implements JEDEC file generation. I'm marking as draft right now, b/c while the core works, some things are incomplete. However, I would appreciate feedback now that I have something working. I'm also happy to split this into multiple issues/PRs:

* [ ] Bail if JEDEC is used without `--compress` option.
  * This is in line w/ Lattice tools.
* [ ] Feature Row, Feature Bits, and `USERCODE` bits generation.
* [ ] ECP5 and MachXO3 support.
  * It is not clear to me that JEDEC programming is meaningful for ECP5. It's probably only used to set Feature Row, Feature Bits (sic, different from Feature Row), and `USERCODE`, and `IDCODE` (? I didn't know you could do that). SVF may work just fine for that purpose. The MachXO families really do need JED support, however, thanks to internal flash programming.
  * The "usable pages" on page 49 of FPGA-TN-02155 do not actually add up to the number of fuses on each MachXO2 variant. I assume this is also the case for MachXO3, but have not generated JED files to check yet.
* [ ] Diamond compatibility.
  * Both STEP-MXO2 and openFPGALoader [expect](https://github.com/trabucayre/openFPGALoader/blob/c417ce6746fc5504192132ba9aa3c9f0cb087194/src/lattice.cpp#L426) certain `NOTE` fields to be present in the JEDEC file. I added a `--jed-note` field as a _limited_ workaround for STEP-MXO2.
  * STEP-MXO2 relies on parsing the package number in the JEDEC file, for instance: `DEVICE NAME: LCMXO2-4000HC-6CSBGA132`. Presently, the textual format only includes part and package number as a `.comment`, rather than a structured field I can rely on not changing. **Are there any objections to adding a package field to the textual format**?
* [ ] User Flash Memory support
  * The MachXO2/3 User Flash Memory probably works with open tools now that #232 is in. However, there isn't currently a great way to program your own file onto the User Flash Memory with open tools. As far as Lattice is concerned, User Flash Memory fuses immediately follow Config fuses in JEDEC files, and are programmed the same way. Despite this, openFPGALoader parses `NOTE` fields to find the User Flash Memory, so this also ties into Diamond compatibility.
  * Lattice generates User Flash Memory fuses at synthesis time, by reading the file pointed to by the `UFM_INIT_FILE_NAME` `parameter` of an `EFB` primitive instantiation. **My proposal is to add a `.ufm_init`/`.ufm_start_page`. field to the textual format, analogous to `.ebr_init` for Lattice compat with `UFM_INIT_FILE_NAME`, with maybe a command-line override to `ecppack` to change out the UFM image at packing time**.

1. For modifying config bits on MachXO2, Lattice's own official tools seem to like parsing JED files instead of SVFs. SVFs seem to be more of a side effect of JED generation/manipulation in Diamond Programmer.