### PR TITLE
Find all components of Python at the same time

### DIFF
--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -54,10 +54,11 @@ else()
 endif()
 set(Boost_NO_BOOST_CMAKE ON)
 
-find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 if (BUILD_PYTHON)
-    find_package(Python3 3.5 REQUIRED COMPONENTS Development)
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter Development.Module)
     set(PythonInstallTarget "pytrellis")
+else()
+    find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
 endif()
 
 find_package(Boost REQUIRED COMPONENTS ${boost_libs})

--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.31)
 project(libtrellis)
 
 option(BUILD_PYTHON "Build Python Integration" ON)


### PR DESCRIPTION
This is explicitly recommended by the FindPython module documentation
and is required to avoid failed builds on some systems. See:
https://cmake.org/cmake/help/latest/module/FindPython.html