### PR TITLE
[ecppll] Fixed lint error in the generated PLL module

### DIFF
--- a/libtrellis/tools/ecppll.cpp
+++ b/libtrellis/tools/ecppll.cpp
@@ -480,12 +480,18 @@ void write_pll_config(const pll_params & params, const string &name, ofstream& f
       file << "        .CLKOS(" << params.clkout0_name << "),\n";
     else
       file << "        .CLKOS(" << params.secondary[0].name << "),\n";
+  } else {
+      file << "        .CLKOS(),\n";
   }
   if(params.secondary[1].enabled){
     file << "        .CLKOS2(" << params.secondary[1].name << "),\n";
+  } else {
+    file << "        .CLKOS2(),\n";
   }
   if(params.secondary[2].enabled){
     file << "        .CLKOS3(" << params.secondary[2].name << "),\n";
+  } else {
+    file << "        .CLKOS3(),\n";
   }
 
   if(params.internal_feedback || params.mode == pll_mode::HIGHRES)
@@ -522,7 +528,12 @@ void write_pll_config(const pll_params & params, const string &name, ofstream& f
   }
   file << "        .PLLWAKESYNC(1'b0),\n";
   file << "        .ENCLKOP(1'b0),\n";
-  file << "        .LOCK(locked)\n";
+  file << "        .LOCK(locked),\n";
+  file << "        .ENCLKOS(),\n";
+  file << "        .ENCLKOS2(),\n";
+  file << "        .ENCLKOS3(),\n";
+  file << "        .INTLOCK(),\n";
+  file << "        .REFCLK()\n";
   file << "	);\n";
   file << "endmodule\n";
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/YosysHQ/prjtrellis/issues/249

It adds to the instantiation of the PLL module the unused signals to fix the lint errors.

Here is an example of the generated code with `ecppll -i 25 -o 120 -f pll.v`:
```
// diamond 3.7 accepts this PLL
// diamond 3.8-3.9 is untested
// diamond 3.10 or higher is likely to abort with error about unable to use feedback signal
// cause of this could be from wrong CPHASE/FPHASE parameters
module pll
(
    input clkin, // 25 MHz, 0 deg
    output clkout0, // 120 MHz, 0 deg
    output locked
);
(* FREQUENCY_PIN_CLKI="25" *)
(* FREQUENCY_PIN_CLKOP="120" *)
(* ICP_CURRENT="12" *) (* LPF_RESISTOR="8" *) (* MFG_ENABLE_FILTEROPAMP="1" *) (* MFG_GMCREF_SEL="2" *)
EHXPLLL #(
        .PLLRST_ENA("DISABLED"),
        .INTFB_WAKE("DISABLED"),
        .STDBY_ENABLE("DISABLED"),
        .DPHASE_SOURCE("DISABLED"),
        .OUTDIVIDER_MUXA("DIVA"),
        .OUTDIVIDER_MUXB("DIVB"),
        .OUTDIVIDER_MUXC("DIVC"),
        .OUTDIVIDER_MUXD("DIVD"),
        .CLKI_DIV(5),
        .CLKOP_ENABLE("ENABLED"),
        .CLKOP_DIV(5),
        .CLKOP_CPHASE(2),
        .CLKOP_FPHASE(0),
        .FEEDBK_PATH("CLKOP"),
        .CLKFB_DIV(24)
    ) pll_i (
        .RST(1'b0),
        .STDBY(1'b0),
        .CLKI(clkin),
        .CLKOP(clkout0),
        .CLKOS(),
        .CLKOS2(),
        .CLKOS3(),
        .CLKFB(clkout0),
        .CLKINTFB(),
        .PHASESEL0(1'b0),
        .PHASESEL1(1'b0),
        .PHASEDIR(1'b1),
        .PHASESTEP(1'b1),
        .PHASELOADREG(1'b1),
        .PLLWAKESYNC(1'b0),
        .ENCLKOP(1'b0),
        .LOCK(locked),
        .ENCLKOS(),
        .ENCLKOS2(),
        .ENCLKOS3(),
        .INTLOCK(),
        .REFCLK()
	);
endmodule

```