### PR TITLE
Remove Boost `system` component lookup

### DIFF
--- a/libtrellis/CMakeLists.txt
+++ b/libtrellis/CMakeLists.txt
@@ -46,7 +46,7 @@ if (WASI)
     endif()
 endif()
 
-set(boost_libs filesystem program_options system)
+set(boost_libs filesystem program_options)
 if (Threads_FOUND)
     list(APPEND boost_libs thread)
 else()
@@ -62,6 +62,7 @@ else()
 endif()
 
 find_package(Boost REQUIRED COMPONENTS ${boost_libs})
+
 
 find_package(Git)
 


### PR DESCRIPTION
This PR removes the Boost `system` component

This closes #251

See Also: https://github.com/YosysHQ/nextpnr/pull/1589