### PR TITLE
libtrellis: fix MachXO2/XO3 global clock routing into the left CIB columns (unblocks 2000/4000/7000 and XO3 in nextpnr)

### DIFF
--- a/libtrellis/src/RoutingGraph.cpp
+++ b/libtrellis/src/RoutingGraph.cpp
@@ -468,11 +468,17 @@ RoutingId RoutingGraph::find_machxo2_global_position(int row, int col, const std
         // The remaining two globals should come from BRANCHES from the right.
         // But since we run into the chip's edge, we route them to the current
         // column (and only the current column!) here.
-        if(col > 1)
-            candidate_cols.push_back(col - 2);
+        // Prefer the tile's own column first. Column 0 advertises six globals
+        // (see generate_global_info_machxo2), which overlap the pairs owned by
+        // columns 2..4; searching col-2 first therefore attributed column 2's
+        // U/D->BRANCH arcs to column 0, leaving column 2's BRANCH wires with no
+        // uphill pips and making two globals unroutable into columns 2-4
+        // (2000: globals 0/4, 1200: globals 1/5). Own column, then left, then right.
+        candidate_cols.push_back(col);
         if(col > 0)
             candidate_cols.push_back(col - 1);
-        candidate_cols.push_back(col);
+        if(col > 1)
+            candidate_cols.push_back(col - 2);
         if(col < max_col)
             candidate_cols.push_back(col + 1);
 


### PR DESCRIPTION
## Summary

This fixes a bug in the MachXO2/MachXO3 routing-graph builder that makes two of the eight global clocks unroutable into the first CIB columns on every density. In practice it **unblocks nextpnr-machxo2 on the densities beyond the default 1200**: the LCMXO2-2000HC (and by the same census the 4000, 7000 and the MachXO3 1300/2100/4300/9400) could not route a global clock into the left edge of the fabric with the current graph, and the 1200 only worked by luck of DCC assignment.

With this change, the same design places, routes, meets timing and packs on both an LCMXO2-1200HC and an LCMXO2-2000HC using nextpnr-machxo2 built with `-DMACHXO2_DEVICES="1200;2000"`.

## What it enables

- **New nextpnr-machxo2 targets become usable.** nextpnr already lists 256/640/1200/2000/4000/7000 and the XO3 parts as buildable chipdbs, but any chipdb generated from the current graph inherits the missing arcs. After this fix the 2000-class and 4000-class graphs have every global branch wire connected in every column, so enabling those devices in nextpnr produces chipdbs that can actually route clocks.
- **Deterministic global routing on the 1200.** Today a design passes or fails depending on which DCC the placer picks for each clock and whether any clocked cell lands in columns 2-4. That is why the same netlist can route under one build (e.g. the yowasp wasm package) and fail under another (a native build) with byte-identical chipdbs.
- **An honest graph on the 256/640.** Column-0 branch wires that borrowed column 2's arcs now show no uphill pip instead of a pip whose configuration bits belong to a different tile.

## Problem

`find_machxo2_global_position()` gives each `BRANCH_HPBX*` wire the nominal position of the column whose U/D connection feeds it, trying candidate columns in the order `col-2, col-1, col, col+1`. Column 0's `ud_conns` entry advertises six globals (`generate_global_info_machxo2`), which overlap the pairs owned by columns 2–4. For a tile in column 2 the search matches column 0 first, so column 2's own U/D→BRANCH arcs are attributed to column 0's wires.

In the resulting graph, column 0's BRANCH wires for those globals have two uphill pips and column 2's have none. Two of the eight globals can never reach CIBs in columns 2–4. Which pair depends on `start_stride`:

| Device | Unroutable globals |
|---|---|
| LCMXO2-2000 / LCMXO3-2100 | 0 and 4 |
| LCMXO2-1200 / LCMXO3-1300 / LCMXO3-9400 | 1 and 5 |
| LCMXO2-4000 / LCMXO3-4300 | 2 and 6 |
| LCMXO2-7000 / LCMXO3-6900 | 3 and 7 |

nextpnr-machxo2 then fails whenever a clocked cell is placed in those columns and the DCC chosen for that clock is one of the affected globals:

```
ERROR: Failed to route net 'sys_clk$glb_clk' from X13/Y8/G_CLKO0_DCC to X3/Y2/CLK3_SLICE using dedicated routing.
```

## Fix

Search the tile's own column first, then the left neighbours, then the right. Interior columns own disjoint global pairs, so their result is unchanged; only the left-edge overlap case moves. One function, nine lines.
